### PR TITLE
Update personal bio.

### DIFF
--- a/config/authors/Techno-Disaster.json
+++ b/config/authors/Techno-Disaster.json
@@ -1,6 +1,6 @@
 {
   "name": "Jayesh Nirve",
-  "bio": "Google DSC Lead, KJSCE |  Google Code-in Finalist | Collab work @Team-Definitely, @anitab-org",
+  "bio": "Google DSC Lead, KJSCE | GCI, GSoC @CCExtractor | Collab work @Team-Definitely",
   "photoURL": "https://avatars.githubusercontent.com/Techno-Disaster",
   "githubURL": "https://github.com/Techno-Disaster"
 }


### PR DESCRIPTION
I recently changed my github bio, but devlibrary still shows the old one. Maybe we can get the bio using Github users [api](https://docs.github.com/en/rest/reference/users) and get this every time? Or use a cron job and update config/authors/[author].json every few days or so. (the latter is just a hack)