### PR TITLE
Fix typo: update title of article

### DIFF
--- a/config/android/blogs/hide-internal-members-of-kotlin-module-from-jvm-c7730507fb17.json
+++ b/config/android/blogs/hide-internal-members-of-kotlin-module-from-jvm-c7730507fb17.json
@@ -5,7 +5,7 @@
     "patilshreyas"
   ],
   "author": "Shreyas Patil",
-  "title": "Hide internl members of Kotlin Module from JVM ",
+  "title": "Hide internal members of Kotlin Module from JVM ",
   "link": "https://medium.com/scalereal/hide-internal-members-of-kotlin-module-from-jvm-c7730507fb17",
   "tags": [
     "kotlin"


### PR DESCRIPTION
Updated the title of the article "Hide internal members of Kotlin Module from JVM" where earlier there was a typo in word _"internal"_