### PR TITLE
Deploy fewer preview channgels

### DIFF
--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           repoToken: '${{ secrets.GITHUB_TOKEN }}'
           firebaseServiceAccount: '${{ secrets.FIREBASE_SERVICE_ACCOUNT_UGC_SITE_DEV }}'
+          expires: 3d
           projectId: ugc-site-dev
         env:
           FIREBASE_CLI_PREVIEWS: hostingchannels

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -16,7 +16,10 @@
 # https://github.com/firebase/firebase-tools
 
 name: Firebase Hosting Preview
-on: pull_request
+on: 
+  pull_request:
+    paths:
+      - 'app/**'
 jobs:
   build_and_preview:
     if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
We got this error recently:
```
    "error": "HTTP Error: 429, Couldn't create channel on `projects/867368912668/sites/ugc-site-dev`: channel quota reached."
```

Making two changes:

  1. Only run the deploy on the `app` path
  2. Channels expire in 3 days