### PR TITLE
Switch to paths_ignore

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,11 @@ name: Build
 
 on:
   push:
-    paths:
-      - 'app/**'
-      - 'functions/**'
-      - 'shared/**'
+    paths-ignore:
+      - 'config/**'
   pull_request:
-    paths:
-      - 'app/**'
-      - 'functions/**'
-      - 'shared/**'
+    paths-ignore:
+      - 'config/**'
 
 env:
   CI: true


### PR DESCRIPTION
See #186 
See: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#onpushpull_requestpaths

```
When all the path names match patterns in paths-ignore, the workflow will not run. GitHub evaluates patterns defined in paths-ignore against the path name. A workflow with the following path filter will only run on push events that include at least one file outside the docs directory at the root of the repository.
```