### PR TITLE
Reduce GitHub API usage

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -16,6 +16,10 @@
         "function": "queryProxy"
       },
       {
+        "source": "/api/emojis",
+        "function": "emojis"
+      },
+      {
         "source": "/api/elasticSearch",
         "function": "elasticSearch"
       },

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -658,6 +658,29 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.51.tgz",
       "integrity": "sha512-KANw+MkL626tq90l++hGelbl67irOJzGhUJk6a1Bt8QHOeh9tztJx+L0AqttraWKinmZn7Qi5lJZJzx45Gq0dg=="
     },
+    "@types/node-fetch": {
+      "version": "2.5.12",
+      "resolved": "https://registry.npmjs.org/@types/node-fetch/-/node-fetch-2.5.12.tgz",
+      "integrity": "sha512-MKgC4dlq4kKNa/mYrwpKfzQMB5X3ee5U6fSprkKpToBqBmX4nFZL9cW5jl6sWn+xpRJ7ypWh2yyqqr8UUCstSw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
+    },
     "@types/qs": {
       "version": "6.9.7",
       "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",

--- a/functions/package.json
+++ b/functions/package.json
@@ -20,12 +20,14 @@
     "firebase-admin": "^9.2.0",
     "firebase-functions": "^3.16.0",
     "marked": "^2.0.7",
+    "node-fetch": "^2.6.1",
     "url-join": "^4.0.1"
   },
   "devDependencies": {
     "@octokit/types": "^6.8.2",
     "@types/cheerio": "^0.22.23",
     "@types/marked": "^2.0.3",
+    "@types/node-fetch": "^2.5.11",
     "@types/url-join": "^4.0.0",
     "firebase-functions-test": "^0.2.0",
     "firebase-tools": "^9.21.0",

--- a/functions/src/github.ts
+++ b/functions/src/github.ts
@@ -15,9 +15,10 @@
  */
 
 import { Octokit } from "@octokit/rest";
-import * as config from "./config";
-
 import fetch from "node-fetch";
+
+import * as config from "./config";
+import { getProjectId } from "./project";
 
 export interface GitHubRepo {
   default_branch: string;
@@ -136,7 +137,7 @@ export async function getEmojiMap(): Promise<Record<string, string>> {
   const emojisUrl =
     process.env.FUNCTIONS_EMULATOR === "true"
       ? `http://localhost:5000/api/emojis`
-      : `https://${process.env.GCP_PROJECT}.web.app/api/emojis`;
+      : `https://${getProjectId()}.web.app/api/emojis`;
   const res = await fetch(emojisUrl);
 
   // This is a map from emoji shortcode to image URL, for example:

--- a/functions/src/github.ts
+++ b/functions/src/github.ts
@@ -17,6 +17,15 @@
 import { Octokit } from "@octokit/rest";
 import * as config from "./config";
 
+import fetch from "node-fetch";
+
+export interface GitHubRepo {
+  default_branch: string;
+  stargazers_count: number;
+  forks_count: number;
+  pushed_at: string;
+}
+
 let _gh: Octokit | undefined = undefined;
 
 function gh(): Octokit {
@@ -29,7 +38,10 @@ function gh(): Octokit {
   return _gh;
 }
 
-export async function getRepo(owner: string, repo: string) {
+export async function getRepo(
+  owner: string,
+  repo: string
+): Promise<GitHubRepo> {
   const res = await gh()
     .repos.get({
       owner,
@@ -120,12 +132,17 @@ export async function getFileContent(
 }
 
 export async function getEmojiMap(): Promise<Record<string, string>> {
-  const res = await gh().emojis.get();
+  // We proxy this through our own function to reduce API calls
+  const emojisUrl =
+    process.env.FUNCTIONS_EMULATOR === "true"
+      ? `http://localhost:5000/api/emojis`
+      : `https://${process.env.GCP_PROJECT}.web.app/api/emojis`;
+  const res = await fetch(emojisUrl);
 
   // This is a map from emoji shortcode to image URL, for example:
   // 1st_place_medal: "https://github.githubassets.com/images/icons/emoji/unicode/1f947.png?v8",
   // algeria: "https://github.githubassets.com/images/icons/emoji/unicode/1f1e9-1f1ff.png?v8",
-  const urlMap = res.data;
+  const urlMap = (await res.json()) as Record<string, string>;
 
   const map: Record<string, string> = {};
 

--- a/functions/src/project.ts
+++ b/functions/src/project.ts
@@ -1,0 +1,41 @@
+import * as admin from "firebase-admin";
+
+export function getProjectId(): string {
+  if (isStringDefined(process.env.GCP_PROJECT)) {
+    return process.env.GCP_PROJECT;
+  }
+
+  if (isStringDefined(process.env.GCLOUD_PROJECT)) {
+    return process.env.GCLOUD_PROJECT;
+  }
+
+  if (isStringDefined(process.env.FIREBASE_CONFIG)) {
+    try {
+      const json = JSON.parse(process.env.FIREBASE_CONFIG);
+      const projectId = json.project_id;
+      if (isStringDefined(projectId)) {
+        return projectId;
+      }
+    } catch (e) {
+      // No-op
+    }
+  }
+
+  if (admin.apps.length > 0) {
+    const projectId = admin.apps[0]!.options.projectId;
+    if (isStringDefined(projectId)) {
+      return projectId;
+    }
+  }
+
+  console.warn("Could not determine project id, default to production");
+  return "ugc-site-prod";
+}
+
+function isStringDefined(str: string | undefined): str is string {
+  if (str) {
+    return str.length > 0;
+  }
+
+  return false;
+}

--- a/functions/src/proxy.ts
+++ b/functions/src/proxy.ts
@@ -17,6 +17,8 @@
 import * as functions from "firebase-functions";
 import * as admin from "firebase-admin";
 
+import fetch from "node-fetch";
+
 import { FirestoreQuery, QueryResult } from "../../shared/types/FirestoreQuery";
 
 export const queryProxy = functions
@@ -112,4 +114,20 @@ export const docProxy = functions.https.onRequest(async (req, res) => {
   }
 
   res.json(snap.data());
+});
+
+/**
+ * Proxy https://api.github.com/emojis
+ */
+export const emojis = functions.https.onRequest(async (req, res) => {
+  // Allow CORS
+  res.header("Access-Control-Allow-Origin", "*");
+
+  // Cache at browser for 10 minutes (600s) and on CDN for 12 hours (43200s)
+  res.set("Cache-Control", "public, max-age=600, s-maxage=43200");
+
+  const r = await fetch("https://api.github.com/emojis");
+  const obj = await r.json();
+
+  res.json(obj);
 });

--- a/functions/src/stats.ts
+++ b/functions/src/stats.ts
@@ -15,28 +15,25 @@
  */
 
 import { BlogMetadata } from "../../shared/types/BlogMetadata";
-import { RepoMetadata } from "../../shared/types/RepoMetadata";
 import { BlogData, BlogStats, RepoData, RepoStats } from "../../shared/types";
 
-import * as github from "./github";
+import { GitHubRepo } from "./github";
 
-export async function loadRepoStats(
-  metadata: RepoMetadata,
-  existing: RepoData | undefined
-): Promise<RepoStats> {
+export function makeRepoStats(
+  existing: RepoData | undefined,
+  repo: GitHubRepo
+): RepoStats {
   // Determine the date the content was added to the site
   const dateAdded =
     existing && existing.stats.dateAdded
       ? existing.stats.dateAdded
       : new Date().getTime();
 
-  const repo = await github.getRepo(metadata.owner, metadata.repo);
-
   return {
     stars: repo.stargazers_count,
     forks: repo.forks_count,
     dateAdded,
-    lastUpdated: Date.parse(repo.updated_at),
+    lastUpdated: Date.parse(repo.pushed_at),
   };
 }
 


### PR DESCRIPTION
See #273 

This makes the following optimizations:

 * Only update a repo's content if it has a recent `pushed_at`
 * Proxy the GitHub emojis API
 * Remove separate API call to get the default branch