### PR TITLE
Improve functions error logging

### DIFF
--- a/functions/src/proxy.ts
+++ b/functions/src/proxy.ts
@@ -26,7 +26,7 @@ function isValidCollectionPath(path: string): boolean {
   try {
     db.collection(path);
     return true;
-  } catch (e: unknown) {
+  } catch (e) {
     return false;
   }
 }
@@ -36,7 +36,7 @@ function isValidDocumentPath(path: string): boolean {
   try {
     db.doc(path);
     return true;
-  } catch (e: unknown) {
+  } catch (e) {
     return false;
   }
 }


### PR DESCRIPTION
We're getting some errors like this in docProxy:

```
Error: Value for argument "documentPath" is not a valid resource path. Paths must not contain //.
    at Object.validateResourcePath (/workspace/node_modules/@google-cloud/firestore/build/src/path.js:406:15)
    at Firestore.doc (/workspace/node_modules/@google-cloud/firestore/build/src/index.js:518:16)
    at /workspace/lib/functions/src/proxy.js:110:42
    at cloudFunction (/workspace/node_modules/firebase-functions/lib/providers/https.js:50:16)
    at /layers/google.nodejs.functions-framework/functions-framework/node_modules/@google-cloud/functions-framework/build/src/function_wrappers.js:97:17
    at processTicksAndRejections (internal/process/task_queues.js:79:11) 
```

This should give us more insight to eventually fix them.