### PR TITLE
Limit to 10 selected categories

### DIFF
--- a/app/src/components/CheckboxGroup.vue
+++ b/app/src/components/CheckboxGroup.vue
@@ -30,6 +30,7 @@
           v-model="entry.checked"
           @input="emitValue"
           :id="entry.id"
+          :disabled="!entry.checked && numChecked >= maxSelections"
         />
         <div class="mdc-checkbox__background">
           <svg class="mdc-checkbox__checkmark" viewBox="0 0 24 24">
@@ -68,6 +69,9 @@ export default class CheckboxGroup extends Vue {
   /** Internal value for each key (ex: android, web) */
   @Prop() values!: string[];
 
+  /** Maximum number of selections allowed */
+  @Prop({ default: 100 }) maxSelections!: number;
+
   public entries: CheckboxGroupEntry[] = [];
 
   mounted() {
@@ -95,6 +99,10 @@ export default class CheckboxGroup extends Vue {
    */
   public emitValue() {
     this.$emit("input", this.entries);
+  }
+
+  get numChecked() {
+    return this.entries.filter((e) => e.checked).length;
   }
 }
 </script>

--- a/app/src/components/InfoCircle.vue
+++ b/app/src/components/InfoCircle.vue
@@ -1,0 +1,51 @@
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<template>
+  <div class="info-circle relative">
+    <font-awesome-icon
+      icon="info-circle"
+      class="text-gray-500 hover:text-gray-600 cursor-pointer"
+      size="sm"
+    />
+    <div
+      class="info-circle-msg bg-gray-700 text-white rounded shadow-sm text-xs font-normal max-w-md p-2"
+    >
+      {{ msg }}
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+
+@Component({})
+export default class InfoCircle extends Vue {
+  @Prop() msg!: string;
+}
+</script>
+
+<style scoped lang="postcss">
+.info-circle-msg {
+  display: none;
+}
+
+.info-circle:hover .info-circle-msg {
+  position: absolute;
+  display: block;
+  width: max-content;
+}
+</style>

--- a/app/src/components/ProjectFilters.vue
+++ b/app/src/components/ProjectFilters.vue
@@ -47,13 +47,17 @@
         </div>
 
         <div class="section">
-          <p class="font-display font-medium text-sm mb-2 px-2">Category</p>
+          <p class="frc font-display font-medium text-sm mb-2 px-2">
+            Category
+            <InfoCircle class="ml-2" msg="Select up to 10 categories" />
+          </p>
 
           <CheckboxGroup
             prefix="category"
             :keys="product.tags.map((t) => t.label)"
             :values="product.tags.map((t) => t.value)"
             v-model="categories"
+            :maxSelections="10"
           />
         </div>
       </div>
@@ -64,6 +68,7 @@
 <script lang="ts">
 import { Component, Vue, Prop, Watch } from "vue-property-decorator";
 import RadioGroup from "@/components/RadioGroup.vue";
+import InfoCircle from "@/components/InfoCircle.vue";
 import CheckboxGroup, {
   CheckboxGroupEntry,
 } from "@/components/CheckboxGroup.vue";
@@ -73,6 +78,7 @@ import { ProductConfig } from "../../../shared/types";
   components: {
     RadioGroup,
     CheckboxGroup,
+    InfoCircle,
   },
 })
 export default class ProjectFilters extends Vue {

--- a/app/src/plugins/icons.ts
+++ b/app/src/plugins/icons.ts
@@ -38,6 +38,7 @@ import {
   faExclamationCircle,
   faFilter,
   faChevronDown,
+  faInfoCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
 import { faGithub, faMedium } from "@fortawesome/free-brands-svg-icons";
@@ -61,6 +62,7 @@ library.add(
   faExclamationCircle,
   faFilter,
   faChevronDown,
+  faInfoCircle,
 
   faGithub,
   faMedium


### PR DESCRIPTION
This limits the user to 10 selected checkboxes when filtering projects to that we don't exceed the limits of Firestore's ARRAY_CONTAINS_ANY queries.

We were getting some errors like this in queryProxy:

```
Error: 3 INVALID_ARGUMENT: 'ARRAY_CONTAINS_ANY' supports up to 10 comparison values.
    at Object.callErrorFromStatus (/workspace/node_modules/@grpc/grpc-js/build/src/call.js:31:26)
    at Object.onReceiveStatus (/workspace/node_modules/@grpc/grpc-js/build/src/client.js:327:49)
    at Object.onReceiveStatus (/workspace/node_modules/@grpc/grpc-js/build/src/client-interceptors.js:299:181)
    at /workspace/node_modules/@grpc/grpc-js/build/src/call-stream.js:130:78
    at processTicksAndRejections (internal/process/task_queues.js:79:11)
Caused by: Error
    at Query._get (/workspace/node_modules/@google-cloud/firestore/build/src/reference.js:1421:23)
    at Query.get (/workspace/node_modules/@google-cloud/firestore/build/src/reference.js:1410:21)
    at /workspace/lib/functions/src/proxy.js:84:26
    at cloudFunction (/workspace/node_modules/firebase-functions/lib/providers/https.js:50:16)
    at /layers/google.nodejs.functions-framework/functions-framework/node_modules/@google-cloud/functions-framework/build/src/invoker.js:98:17
    at processTicksAndRejections (internal/process/task_queues.js:79:11) 
```