### PR TITLE
Add interactive Breadcrumbs to UI pages

### DIFF
--- a/app/src/components/Breadcrumbs.vue
+++ b/app/src/components/Breadcrumbs.vue
@@ -25,10 +25,14 @@
           <font-awesome-icon icon="chevron-right" size="sm" />
         </li>
         <li :key="index" class="last:text-mgray-800 text-gray-400">
-          <a class="hover:underline" v-if="link.clickable" :href="linkPath(index)">
-            {{link.name}}
+          <a
+            class="hover:underline"
+            v-if="link.clickable"
+            :href="linkPath(index)"
+          >
+            {{ link.name }}
           </a>
-          <p v-else>{{link.name}}</p>
+          <p v-else>{{ link.name }}</p>
         </li>
       </template>
     </ol>
@@ -44,14 +48,11 @@ export default class Breadcrumbs extends Vue {
   @Prop() links!: BreadcrumbLink[];
 
   public linkPath(index: number): string {
-    console.log(index)
-    console.log('index')
-    console.log('../'.repeat(this.links.length - index - 1))
     if (index === this.links.length - 1) {
-      return '';
+      return "";
     }
 
-    return './' + '../'.repeat(this.links.length - index - 2);
+    return "./" + "../".repeat(this.links.length - index - 2);
   }
 }
 </script>

--- a/app/src/components/Breadcrumbs.vue
+++ b/app/src/components/Breadcrumbs.vue
@@ -1,0 +1,59 @@
+<!--
+ Copyright 2021 Google LLC
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-->
+
+<template>
+  <nav class="px-std py-3">
+    <ol class="flex flex-wrap gap-2 text-sm">
+      <li>
+        <a class="text-gray-400 hover:underline" href="/">Dev Library</a>
+      </li>
+      <template v-for="(link, index) in links">
+        <li :key="`s-${index}`" aria-hidden="true">
+          <font-awesome-icon icon="chevron-right" size="sm" />
+        </li>
+        <li :key="index" class="last:text-mgray-800 text-gray-400">
+          <a class="hover:underline" v-if="link.clickable" :href="linkPath(index)">
+            {{link.name}}
+          </a>
+          <p v-else>{{link.name}}</p>
+        </li>
+      </template>
+    </ol>
+  </nav>
+</template>
+
+<script lang="ts">
+import { Component, Prop, Vue } from "vue-property-decorator";
+import { BreadcrumbLink } from "../../../shared/types";
+
+@Component
+export default class Breadcrumbs extends Vue {
+  @Prop() links!: BreadcrumbLink[];
+
+  public linkPath(index: number): string {
+    console.log(index)
+    console.log('index')
+    console.log('../'.repeat(this.links.length - index - 1))
+    if (index === this.links.length - 1) {
+      return '';
+    }
+
+    return './' + '../'.repeat(this.links.length - index - 2);
+  }
+}
+</script>
+
+<style scoped lang="postcss"></style>

--- a/app/src/plugins/icons.ts
+++ b/app/src/plugins/icons.ts
@@ -38,6 +38,7 @@ import {
   faExclamationCircle,
   faFilter,
   faChevronDown,
+  faChevronRight,
   faInfoCircle,
 } from "@fortawesome/free-solid-svg-icons";
 import { faBookmark } from "@fortawesome/free-regular-svg-icons";
@@ -62,6 +63,7 @@ library.add(
   faExclamationCircle,
   faFilter,
   faChevronDown,
+  faChevronRight,
   faInfoCircle,
 
   faGithub,

--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -336,7 +336,7 @@ import { BreadcrumbLink } from "../../../shared/types";
 })
 export default class About extends Vue {
   public getBreadcrumbs(): BreadcrumbLink[] {
-    return [{name: 'About', clickable: true}];
+    return [{name: "About", clickable: true}];
   }
 }
 </script>

--- a/app/src/views/About.vue
+++ b/app/src/views/About.vue
@@ -16,6 +16,7 @@
 
 <template>
   <div class="about">
+    <Breadcrumbs :links="getBreadcrumbs()"></Breadcrumbs>
     <div
       id="header"
       class="grid gap-4 grid-cols-6 py-6 lg:py-10 border-b border-gray-100"
@@ -324,13 +325,20 @@
 import { Component, Vue } from "vue-property-decorator";
 
 import MaterialButton from "@/components/MaterialButton.vue";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
+import { BreadcrumbLink } from "../../../shared/types";
 
 @Component({
   components: {
     MaterialButton,
+    Breadcrumbs,
   },
 })
-export default class About extends Vue {}
+export default class About extends Vue {
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [{name: 'About', clickable: true}];
+  }
+}
 </script>
 
 <style scoped lang="postcss">

--- a/app/src/views/Author.vue
+++ b/app/src/views/Author.vue
@@ -15,105 +15,108 @@
 -->
 
 <template>
-  <HeaderBodyLayout
-    style="
-      --header-bg-image-desktop: url('/img/banners/desktop/author-wide.png');
-      --header-bg-image-mobile: url('/img/banners/mobile/author-wide.png');
-    "
-  >
-    <template v-if="loaded" v-slot:header>
-      <!-- Header (Mobile) -->
-      <div class="mobile-only header-image py-6">
-        <div class="flex flex-col items-center gap-2">
-          <CircleImage
-            class="border-white"
-            size="medium"
-            :src="author.metadata.photoURL"
-          />
+  <div>
+    <Breadcrumbs v-if="loaded" :links="getBreadcrumbs()" />
+    <HeaderBodyLayout
+      style="
+        --header-bg-image-desktop: url('/img/banners/desktop/author-wide.png');
+        --header-bg-image-mobile: url('/img/banners/mobile/author-wide.png');
+      "
+    >
+      <template v-if="loaded" v-slot:header>
+        <!-- Header (Mobile) -->
+        <div class="mobile-only header-image py-6">
+          <div class="flex flex-col items-center gap-2">
+            <CircleImage
+              class="border-white"
+              size="medium"
+              :src="author.metadata.photoURL"
+            />
 
-          <!-- Name and bio -->
-          <div class="px-6 py-2 text-center max-w-lg">
-            <h3>
-              {{ author.metadata.name }}
-            </h3>
-            <p class="text-sm mt-2">
-              {{ bio }}
-            </p>
+            <!-- Name and bio -->
+            <div class="px-6 py-2 text-center max-w-lg">
+              <h3>
+                {{ author.metadata.name }}
+              </h3>
+              <p class="text-sm mt-2">
+                {{ bio }}
+              </p>
+            </div>
+
+            <!-- Info card -->
+            <div class="px-6 w-full flex flex-row justify-center">
+              <AuthorExpertiseCard
+                v-if="loaded"
+                class="w-full"
+                :expertise="expertise"
+                :author="author"
+              />
+            </div>
           </div>
+        </div>
 
-          <!-- Info card -->
-          <div class="px-6 w-full flex flex-row justify-center">
+        <!-- Header (Desktop) -->
+        <div class="desktop-only header-image">
+          <div class="py-10 grid grid-cols-12 gap-4 px-std">
+            <!-- Photo, name, and bio -->
+            <div class="col-span-9">
+              <div class="flex flex-row gap-8 items-center">
+                <CircleImage
+                  class="border-none"
+                  size="large"
+                  :src="author.metadata.photoURL"
+                />
+
+                <div>
+                  <h1>
+                    {{ author.metadata.name }}
+                  </h1>
+                  <p class="mt-2 max-w-xl">{{ bio }}</p>
+                </div>
+              </div>
+            </div>
+
+            <!-- Info card -->
             <AuthorExpertiseCard
               v-if="loaded"
-              class="w-full"
+              class="col-span-3"
               :expertise="expertise"
               :author="author"
             />
           </div>
         </div>
-      </div>
+      </template>
 
-      <!-- Header (Desktop) -->
-      <div class="desktop-only header-image">
-        <div class="py-10 grid grid-cols-12 gap-4 px-std">
-          <!-- Photo, name, and bio -->
-          <div class="col-span-9">
-            <div class="flex flex-row gap-8 items-center">
-              <CircleImage
-                class="border-none"
-                size="large"
-                :src="author.metadata.photoURL"
-              />
+      <!-- Body -->
+      <div class="px-std mb-20">
+        <div v-if="loaded">
+          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
+            <!-- Video Interview -->
+            <iframe
+              v-if="loaded && author.metadata.interviewVideoId"
+              class="max-w-full rounded-lg overflow-hidden bg-gray-200"
+              width="560"
+              height="315"
+              :src="`https://www.youtube.com/embed/${author.metadata.interviewVideoId}`"
+              title="YouTube video player"
+              frameborder="0"
+              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+              allowfullscreen
+            ></iframe>
 
-              <div>
-                <h1>
-                  {{ author.metadata.name }}
-                </h1>
-                <p class="mt-2 max-w-xl">{{ bio }}</p>
-              </div>
-            </div>
+            <!-- Projects-->
+            <RepoOrBlogCard
+              v-for="project in projects"
+              :key="project.data.id"
+              :project="project"
+              :showLogo="true"
+              :showTags="false"
+            />
           </div>
-
-          <!-- Info card -->
-          <AuthorExpertiseCard
-            v-if="loaded"
-            class="col-span-3"
-            :expertise="expertise"
-            :author="author"
-          />
         </div>
       </div>
-    </template>
-
-    <!-- Body -->
-    <div class="px-std mb-20">
-      <div v-if="loaded">
-        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
-          <!-- Video Interview -->
-          <iframe
-            v-if="loaded && author.metadata.interviewVideoId"
-            class="max-w-full rounded-lg overflow-hidden bg-gray-200"
-            width="560"
-            height="315"
-            :src="`https://www.youtube.com/embed/${author.metadata.interviewVideoId}`"
-            title="YouTube video player"
-            frameborder="0"
-            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-            allowfullscreen
-          ></iframe>
-
-          <!-- Projects-->
-          <RepoOrBlogCard
-            v-for="project in projects"
-            :key="project.data.id"
-            :project="project"
-            :showLogo="true"
-            :showTags="false"
-          />
-        </div>
-      </div>
-    </div>
-  </HeaderBodyLayout>
+    </HeaderBodyLayout>
+  </div>
 </template>
 
 <script lang="ts">
@@ -127,13 +130,14 @@ import RepoOrBlogCard from "@/components/RepoOrBlogCard.vue";
 import HeaderBodyLayout from "@/components/HeaderBodyLayout.vue";
 import CircleImage from "@/components/CircleImage.vue";
 import AuthorExpertiseCard from "@/components/AuthorExpertiseCard.vue";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
 
 import {
   fetchAuthor,
   queryAuthorProjects,
   wrapInHolders,
 } from "@/plugins/data";
-import { AuthorData, BlogData, RepoData } from "../../../shared/types";
+import { AuthorData, BlogData, BreadcrumbLink, RepoData } from "../../../shared/types";
 
 @Component({
   components: {
@@ -142,10 +146,18 @@ import { AuthorData, BlogData, RepoData } from "../../../shared/types";
     HeaderBodyLayout,
     CircleImage,
     AuthorExpertiseCard,
+    Breadcrumbs,
   },
 })
 export default class Author extends Vue {
   private uiModule = getModule(UIModule, this.$store);
+
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [
+      {name: 'Authors', clickable: true},
+      {name: this.author?.metadata?.name ?? 'Author', clickable: true}
+    ];
+  }
 
   public id!: string;
   public author: AuthorData | null = null;

--- a/app/src/views/Author.vue
+++ b/app/src/views/Author.vue
@@ -137,7 +137,12 @@ import {
   queryAuthorProjects,
   wrapInHolders,
 } from "@/plugins/data";
-import { AuthorData, BlogData, BreadcrumbLink, RepoData } from "../../../shared/types";
+import {
+  AuthorData,
+  BlogData,
+  BreadcrumbLink,
+  RepoData,
+} from "../../../shared/types";
 
 @Component({
   components: {
@@ -154,8 +159,8 @@ export default class Author extends Vue {
 
   public getBreadcrumbs(): BreadcrumbLink[] {
     return [
-      {name: 'Authors', clickable: true},
-      {name: this.author?.metadata?.name ?? 'Author', clickable: true}
+      { name: "Authors", clickable: true },
+      { name: this.author?.metadata?.name ?? "Author", clickable: true },
     ];
   }
 

--- a/app/src/views/Authors.vue
+++ b/app/src/views/Authors.vue
@@ -154,7 +154,7 @@ export default class Authors extends Vue {
   private uiModule = getModule(UIModule, this.$store);
 
   public getBreadcrumbs(): BreadcrumbLink[] {
-    return [{name: 'Authors', clickable: true}];
+    return [{ name: "Authors", clickable: true }];
   }
 
   public authorFilter = "";

--- a/app/src/views/Authors.vue
+++ b/app/src/views/Authors.vue
@@ -16,6 +16,7 @@
 
 <template>
   <div>
+    <Breadcrumbs :links="getBreadcrumbs()" />
     <!-- Header -->
     <div
       class="header-image py-10 lg:py-20 px-std border-b border-gray-100"
@@ -137,18 +138,24 @@ import UIModule from "@/store/ui";
 
 import MaterialButton from "@/components/MaterialButton.vue";
 import CircleImage from "@/components/CircleImage.vue";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
 
-import { AuthorData } from "../../../shared/types";
+import { AuthorData, BreadcrumbLink } from "../../../shared/types";
 import { queryAuthors } from "@/plugins/data";
 
 @Component({
   components: {
     MaterialButton,
     CircleImage,
+    Breadcrumbs,
   },
 })
 export default class Authors extends Vue {
   private uiModule = getModule(UIModule, this.$store);
+
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [{name: 'Authors', clickable: true}];
+  }
 
   public authorFilter = "";
   public authors: AuthorData[] = [];

--- a/app/src/views/ContentPolicy.vue
+++ b/app/src/views/ContentPolicy.vue
@@ -186,7 +186,7 @@ import { BreadcrumbLink } from "../../../shared/types";
 })
 export default class ContentPolicy extends Vue {
   public getBreadcrumbs(): BreadcrumbLink[] {
-    return [{name: 'Content Policy', clickable: true}];
+    return [{ name: "Content Policy", clickable: true }];
   }
 }
 </script>

--- a/app/src/views/ContentPolicy.vue
+++ b/app/src/views/ContentPolicy.vue
@@ -16,6 +16,7 @@
 
 <template>
   <div>
+    <Breadcrumbs :links="getBreadcrumbs()" />
     <!-- Header -->
     <div class="grid grid-cols-10 gap-4 border-b border-gray-100">
       <div class="col-start-2 col-span-8">
@@ -175,11 +176,19 @@
 
 <script lang="ts">
 import { Component, Vue } from "vue-property-decorator";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
+import { BreadcrumbLink } from "../../../shared/types";
 
 @Component({
-  components: {},
+  components: {
+    Breadcrumbs,
+  },
 })
-export default class ContentPolicy extends Vue {}
+export default class ContentPolicy extends Vue {
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [{name: 'Content Policy', clickable: true}];
+  }
+}
 </script>
 
 <style scoped lang="postcss">

--- a/app/src/views/Product.vue
+++ b/app/src/views/Product.vue
@@ -15,170 +15,173 @@
 -->
 
 <template>
-  <HeaderBodyLayout
-    style="
-      --header-bg-image-desktop: url('/img/banners/desktop/product-wide.png');
-      --header-bg-image-mobile: url('/img/banners/mobile/product-wide.png');
-    "
-  >
-    <template v-slot:header>
-      <!-- Header (Mobile) -->
-      <div class="mobile-only header-image">
-        <div class="mobile-only frc px-std py-4 border-b border-gray-100">
-          <ProductLogo size="small" :productKey="product.key" />
+  <div>
+    <Breadcrumbs :links="getBreadcrumbs()" />
+    <HeaderBodyLayout
+      style="
+        --header-bg-image-desktop: url('/img/banners/desktop/product-wide.png');
+        --header-bg-image-mobile: url('/img/banners/mobile/product-wide.png');
+      "
+    >
+      <template v-slot:header>
+        <!-- Header (Mobile) -->
+        <div class="mobile-only header-image">
+          <div class="mobile-only frc px-std py-4 border-b border-gray-100">
+            <ProductLogo size="small" :productKey="product.key" />
 
-          <h1 class="ml-2">
-            {{ product.name }}
-          </h1>
-        </div>
-      </div>
-
-      <!-- Header (Desktop) -->
-      <div class="desktop-only header-image">
-        <div
-          class="lg:py-4 xl:py-10 px-std grid grid-cols-10 gap-4 border-b border-gray-100"
-        >
-          <div class="col-span-4 pt-2">
-            <div class="frc">
-              <ProductLogo
-                class="mr-4"
-                size="medium"
-                :productKey="product.key"
-              />
-              <h1>
-                {{ product.name }}
-              </h1>
-            </div>
-
-            <p class="mt-2">{{ product.description }}</p>
-            <a :href="product.docsUrl" target="blank">
-              <MaterialButton type="secondary" class="mt-8">
-                Official docs
-                <font-awesome-icon icon="external-link-alt" class="ml-1" />
-              </MaterialButton>
-            </a>
+            <h1 class="ml-2">
+              {{ product.name }}
+            </h1>
           </div>
         </div>
-      </div>
-    </template>
 
-    <!-- Body -->
-    <div class="grid grid-cols-10 gap-4 mb-20 px-std pt-4 lg:pt-8">
-      <!-- Filters (Desktop) -->
-      <div v-if="$mq === 'desktop'" class="lg:col-span-2">
-        <ProjectFilters v-model="filters" :product="product" />
-      </div>
+        <!-- Header (Desktop) -->
+        <div class="desktop-only header-image">
+          <div
+            class="lg:py-4 xl:py-10 px-std grid grid-cols-10 gap-4 border-b border-gray-100"
+          >
+            <div class="col-span-4 pt-2">
+              <div class="frc">
+                <ProductLogo
+                  class="mr-4"
+                  size="medium"
+                  :productKey="product.key"
+                />
+                <h1>
+                  {{ product.name }}
+                </h1>
+              </div>
 
-      <!-- Filters (Mobile) -->
-      <div
-        v-if="$mq === 'mobile'"
-        v-show="showFilterOverlay"
-        class="mobile-only scrim"
-      >
-        <!-- scrim -->
-      </div>
-      <transition name="slide-in-left">
+              <p class="mt-2">{{ product.description }}</p>
+              <a :href="product.docsUrl" target="blank">
+                <MaterialButton type="secondary" class="mt-8">
+                  Official docs
+                  <font-awesome-icon icon="external-link-alt" class="ml-1" />
+                </MaterialButton>
+              </a>
+            </div>
+          </div>
+        </div>
+      </template>
+
+      <!-- Body -->
+      <div class="grid grid-cols-10 gap-4 mb-20 px-std pt-4 lg:pt-8">
+        <!-- Filters (Desktop) -->
+        <div v-if="$mq === 'desktop'" class="lg:col-span-2">
+          <ProjectFilters v-model="filters" :product="product" />
+        </div>
+
+        <!-- Filters (Mobile) -->
         <div
           v-if="$mq === 'mobile'"
           v-show="showFilterOverlay"
-          class="mobile-only fixed right-0 top-0 pt-20 w-full h-full"
+          class="mobile-only scrim"
         >
-          <div class="bg-white rounded-l overflow-hidden w-2/3 ml-auto">
-            <ProjectFilters
-              v-model="filters"
-              :product="product"
-              :mobile="true"
-            />
-            <div
-              class="border-t border-gray-200 flex flex-row-reverse gap-2 p-2"
-            >
-              <MaterialButton
-                type="primary"
-                @click.native="showFilterOverlay = false"
-                >Done</MaterialButton
-              >
-
-              <MaterialButton type="secondary" @click.native="resetFilters()"
-                >Reset</MaterialButton
-              >
-            </div>
-          </div>
+          <!-- scrim -->
         </div>
-      </transition>
-
-      <!-- Cards -->
-      <div v-show="hasContent" class="col-span-10 lg:col-span-8">
-        <!-- Filter Chips -->
-        <div v-if="filters" class="flex flex-row flex-wrap">
-          <!-- Show filters button (mobile) -->
-          <div class="mobile-only">
-            <div class="flex flex-row mr-2 mb-4">
-              <div class="filter-chip" @click="showFilterOverlay = true">
-                <font-awesome-icon icon="filter" size="sm" class="mr-2" />
-                <span>Filters</span>
-              </div>
-            </div>
-          </div>
-
-          <div v-for="item in filters.types" :key="item.value">
-            <div
-              v-if="item.checked"
-              class="mr-2 mb-4 filter-chip"
-              @click="removeFilterType(item.value)"
-            >
-              <span class="mr-2">{{ item.key }}</span>
-              <font-awesome-icon icon="times" class="ml-px" size="sm" />
-            </div>
-          </div>
-
-          <div v-for="item in filters.categories" :key="item.value">
-            <div
-              v-if="item.checked"
-              class="mr-2 mb-4 filter-chip"
-              @click="removeFilterCategory(item.value)"
-            >
-              <span class="mr-2">{{ item.key }}</span>
-              <font-awesome-icon icon="times" class="ml-px" size="sm" />
-            </div>
-          </div>
-        </div>
-
-        <div id="projects">
+        <transition name="slide-in-left">
           <div
-            v-if="visibleProjects.length === 0"
-            class="mt-4 frc justify-center py-20 text-gray-400"
+            v-if="$mq === 'mobile'"
+            v-show="showFilterOverlay"
+            class="mobile-only fixed right-0 top-0 pt-20 w-full h-full"
           >
-            <font-awesome-icon
-              :icon="['fas', 'exclamation-circle']"
-              class="mr-2"
-            />
-            <span>No projects matching your filters.</span>
-          </div>
+            <div class="bg-white rounded-l overflow-hidden w-2/3 ml-auto">
+              <ProjectFilters
+                v-model="filters"
+                :product="product"
+                :mobile="true"
+              />
+              <div
+                class="border-t border-gray-200 flex flex-row-reverse gap-2 p-2"
+              >
+                <MaterialButton
+                  type="primary"
+                  @click.native="showFilterOverlay = false"
+                  >Done</MaterialButton
+                >
 
-          <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
-            <RepoOrBlogCard
-              v-for="project in visibleProjects"
-              :key="project.data.id"
-              :project="project"
-            />
-          </div>
-
-          <div class="flex flex-row justify-center mt-4 lg:mt-6">
-            <MaterialButton
-              v-if="canLoadMore"
-              type="text"
-              @click.native="loadMore"
-            >
-              <div class="frc">
-                <span>Load more</span>
-                <font-awesome-icon icon="chevron-down" class="pt-px ml-2" />
+                <MaterialButton type="secondary" @click.native="resetFilters()"
+                  >Reset</MaterialButton
+                >
               </div>
-            </MaterialButton>
+            </div>
+          </div>
+        </transition>
+
+        <!-- Cards -->
+        <div v-show="hasContent" class="col-span-10 lg:col-span-8">
+          <!-- Filter Chips -->
+          <div v-if="filters" class="flex flex-row flex-wrap">
+            <!-- Show filters button (mobile) -->
+            <div class="mobile-only">
+              <div class="flex flex-row mr-2 mb-4">
+                <div class="filter-chip" @click="showFilterOverlay = true">
+                  <font-awesome-icon icon="filter" size="sm" class="mr-2" />
+                  <span>Filters</span>
+                </div>
+              </div>
+            </div>
+
+            <div v-for="item in filters.types" :key="item.value">
+              <div
+                v-if="item.checked"
+                class="mr-2 mb-4 filter-chip"
+                @click="removeFilterType(item.value)"
+              >
+                <span class="mr-2">{{ item.key }}</span>
+                <font-awesome-icon icon="times" class="ml-px" size="sm" />
+              </div>
+            </div>
+
+            <div v-for="item in filters.categories" :key="item.value">
+              <div
+                v-if="item.checked"
+                class="mr-2 mb-4 filter-chip"
+                @click="removeFilterCategory(item.value)"
+              >
+                <span class="mr-2">{{ item.key }}</span>
+                <font-awesome-icon icon="times" class="ml-px" size="sm" />
+              </div>
+            </div>
+          </div>
+
+          <div id="projects">
+            <div
+              v-if="visibleProjects.length === 0"
+              class="mt-4 frc justify-center py-20 text-gray-400"
+            >
+              <font-awesome-icon
+                :icon="['fas', 'exclamation-circle']"
+                class="mr-2"
+              />
+              <span>No projects matching your filters.</span>
+            </div>
+
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-4">
+              <RepoOrBlogCard
+                v-for="project in visibleProjects"
+                :key="project.data.id"
+                :project="project"
+              />
+            </div>
+
+            <div class="flex flex-row justify-center mt-4 lg:mt-6">
+              <MaterialButton
+                v-if="canLoadMore"
+                type="text"
+                @click.native="loadMore"
+              >
+                <div class="frc">
+                  <span>Load more</span>
+                  <font-awesome-icon icon="chevron-down" class="pt-px ml-2" />
+                </div>
+              </MaterialButton>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </HeaderBodyLayout>
+    </HeaderBodyLayout>
+  </div>
 </template>
 
 <script lang="ts">
@@ -196,6 +199,7 @@ import UIModule from "@/store/ui";
 import MaterialButton from "@/components/MaterialButton.vue";
 import RepoOrBlogCard from "@/components/RepoOrBlogCard.vue";
 import ProjectFilters from "@/components/ProjectFilters.vue";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
 import RadioGroup from "@/components/RadioGroup.vue";
 import CheckboxGroup, {
   CheckboxGroupEntry,
@@ -213,6 +217,7 @@ import {
 import { ProductConfig } from "../../../shared/types";
 import { ALL_PRODUCTS } from "../../../shared/product";
 import { FirestoreQuery } from "../../../shared/types/FirestoreQuery";
+import { BreadcrumbLink } from "../../../shared/types";
 import { getStyle, ProductStyle } from "@/model/product";
 
 const SORT_ADDED = "added";
@@ -227,10 +232,18 @@ const SORT_UPDATED = "updated";
     HeaderBodyLayout,
     ProductLogo,
     ProjectFilters,
+    Breadcrumbs,
   },
 })
 export default class Product extends Vue {
   private uiModule = getModule(UIModule, this.$store);
+
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [
+      {name: "Products", clickable: false},
+      {name: this.product.name, clickable: true},
+    ];
+  }
 
   public showFilterOverlay = false;
   public filters = {

--- a/app/src/views/Product.vue
+++ b/app/src/views/Product.vue
@@ -240,8 +240,8 @@ export default class Product extends Vue {
 
   public getBreadcrumbs(): BreadcrumbLink[] {
     return [
-      {name: "Products", clickable: false},
-      {name: this.product.name, clickable: true},
+      { name: "Products", clickable: false },
+      { name: this.product.name, clickable: true },
     ];
   }
 

--- a/app/src/views/Repo.vue
+++ b/app/src/views/Repo.vue
@@ -97,7 +97,9 @@
                 >All Projects</router-link
               >
             </li>
-            <li><a :href="product.docsUrl" target="_blank">Official Docs</a></li>
+            <li>
+              <a :href="product.docsUrl" target="_blank">Official Docs</a>
+            </li>
           </ul>
 
           <p class="uppercase font-medium mt-4 mb-2">Project</p>
@@ -206,10 +208,10 @@ export default class Repo extends Vue {
 
   public getBreadcrumbs(): BreadcrumbLink[] {
     return [
-      {name: "Products", clickable: false},
-      {name: this.product?.name ?? 'Product', clickable: true},
-      {name: "Repos", clickable: false},
-      {name: this.repo?.metadata.name ?? 'Repo', clickable: true},
+      { name: "Products", clickable: false },
+      { name: this.product?.name ?? "Product", clickable: true },
+      { name: "Repos", clickable: false },
+      { name: this.repo?.metadata.name ?? "Repo", clickable: true },
     ];
   }
 

--- a/app/src/views/Repo.vue
+++ b/app/src/views/Repo.vue
@@ -15,23 +15,67 @@
 -->
 
 <template>
-  <HeaderBodyLayout>
-    <template v-if="loaded" v-slot:header>
-      <!-- Header (Desktop) -->
-      <div class="desktop-only">
-        <div
-          :class="[productStyle.bg, productStyle.text]"
-          class="py-20 grid grid-cols-10 gap-4"
-        >
-          <div class="col-start-2 col-span-7">
-            <h1 :class="[productStyle.text]">
-              {{ repo.metadata.name }}
-            </h1>
-            <p class="mt-2">
-              {{ repo.metadata.longDescription }}
-            </p>
+  <div>
+    <Breadcrumbs v-if="loaded" :links="getBreadcrumbs()" />
+    <HeaderBodyLayout>
+      <template v-if="loaded" v-slot:header>
+        <!-- Header (Desktop) -->
+        <div class="desktop-only">
+          <div
+            :class="[productStyle.bg, productStyle.text]"
+            class="py-20 grid grid-cols-10 gap-4"
+          >
+            <div class="col-start-2 col-span-7">
+              <h1 :class="[productStyle.text]">
+                {{ repo.metadata.name }}
+              </h1>
+              <p class="mt-2">
+                {{ repo.metadata.longDescription }}
+              </p>
 
-            <p v-if="authors.length > 0" class="flex gap-2 mt-2">
+              <p v-if="authors.length > 0" class="flex gap-2 mt-2">
+                <AuthorLink
+                  v-for="author in authors"
+                  :key="author.id"
+                  :author="author"
+                  class="opacity-80 hover:opacity-100"
+                />
+              </p>
+
+              <a
+                target="blank"
+                :href="`https://github.com/${repo.metadata.owner}/${repo.metadata.repo}`"
+              >
+                <MaterialButton type="secondary" class="mt-8">
+                  View on GitHub
+                  <font-awesome-icon icon="external-link-alt" class="ml-1" />
+                </MaterialButton>
+              </a>
+            </div>
+
+            <div class="col-start-9 col-span-2">
+              <p class="pt-1">
+                {{ repo.stats.stars }}
+                <font-awesome-icon fixed-width icon="star" />
+              </p>
+              <p class="pt-1">
+                {{ repo.stats.forks }}
+                <font-awesome-icon fixed-width icon="code-branch" />
+              </p>
+            </div>
+          </div>
+        </div>
+
+        <!-- Header (Mobile) -->
+        <div class="mobile-only">
+          <div :class="[productStyle.bg, productStyle.text]" class="py-4 px-8">
+            <h2 :class="[productStyle.text]" class="mb-2">
+              {{ repo.metadata.name }}
+            </h2>
+            <p class="opacity-80 text-sm">
+              {{ repo.metadata.shortDescription }}
+            </p>
+            <p v-if="authors.length > 0" class="flex gap-2 mt-4">
               <AuthorLink
                 v-for="author in authors"
                 :key="author.id"
@@ -39,139 +83,100 @@
                 class="opacity-80 hover:opacity-100"
               />
             </p>
-
-            <a
-              target="blank"
-              :href="`https://github.com/${repo.metadata.owner}/${repo.metadata.repo}`"
-            >
-              <MaterialButton type="secondary" class="mt-8">
-                View on GitHub
-                <font-awesome-icon icon="external-link-alt" class="ml-1" />
-              </MaterialButton>
-            </a>
-          </div>
-
-          <div class="col-start-9 col-span-2">
-            <p class="pt-1">
-              {{ repo.stats.stars }}
-              <font-awesome-icon fixed-width icon="star" />
-            </p>
-            <p class="pt-1">
-              {{ repo.stats.forks }}
-              <font-awesome-icon fixed-width icon="code-branch" />
-            </p>
           </div>
         </div>
-      </div>
+      </template>
 
-      <!-- Header (Mobile) -->
-      <div class="mobile-only">
-        <div :class="[productStyle.bg, productStyle.text]" class="py-4 px-8">
-          <h2 :class="[productStyle.text]" class="mb-2">
-            {{ repo.metadata.name }}
-          </h2>
-          <p class="opacity-80 text-sm">
-            {{ repo.metadata.shortDescription }}
-          </p>
-          <p v-if="authors.length > 0" class="flex gap-2 mt-4">
-            <AuthorLink
-              v-for="author in authors"
-              :key="author.id"
-              :author="author"
-              class="opacity-80 hover:opacity-100"
-            />
-          </p>
-        </div>
-      </div>
-    </template>
-
-    <template v-if="loaded" v-slot:sidebar>
-      <!-- Side bar -->
-      <div>
-        <p class="uppercase font-medium mt-4 mb-2">{{ product.name }}</p>
-        <ul class="text-sm">
-          <li>
-            <router-link :to="`/products/${productKey}`"
-              >All Projects</router-link
-            >
-          </li>
-          <li><a :href="product.docsUrl" target="_blank">Official Docs</a></li>
-        </ul>
-
-        <p class="uppercase font-medium mt-4 mb-2">Project</p>
-        <ul class="text-sm">
-          <li><router-link :to="fullPagePath()">Home</router-link></li>
-          <li v-for="p in repo.metadata.pages" :key="p.path">
-            <router-link :to="fullPagePath(p.path)">{{ p.name }}</router-link>
-          </li>
-          <li>
-            <router-link :to="fullPagePath('license')">License</router-link>
-          </li>
-        </ul>
-
-        <div v-if="repo.metadata.links">
-          <p class="uppercase font-medium mt-4 mb-2">Links</p>
+      <template v-if="loaded" v-slot:sidebar>
+        <!-- Side bar -->
+        <div>
+          <p class="uppercase font-medium mt-4 mb-2">{{ product.name }}</p>
           <ul class="text-sm">
-            <li v-for="l in repo.metadata.links" :key="l.href">
-              <a :href="l.href" target="_blank">{{ l.title }}</a>
+            <li>
+              <router-link :to="`/products/${productKey}`"
+                >All Projects</router-link
+              >
+            </li>
+            <li><a :href="product.docsUrl" target="_blank">Official Docs</a></li>
+          </ul>
+
+          <p class="uppercase font-medium mt-4 mb-2">Project</p>
+          <ul class="text-sm">
+            <li><router-link :to="fullPagePath()">Home</router-link></li>
+            <li v-for="p in repo.metadata.pages" :key="p.path">
+              <router-link :to="fullPagePath(p.path)">{{ p.name }}</router-link>
+            </li>
+            <li>
+              <router-link :to="fullPagePath('license')">License</router-link>
             </li>
           </ul>
+
+          <div v-if="repo.metadata.links">
+            <p class="uppercase font-medium mt-4 mb-2">Links</p>
+            <ul class="text-sm">
+              <li v-for="l in repo.metadata.links" :key="l.href">
+                <a :href="l.href" target="_blank">{{ l.title }}</a>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </template>
+
+      <!-- Body -->
+      <div class="grid grid-cols-10 gap-4 mb-10 lg:mb-20">
+        <div
+          v-if="content != null"
+          class="col-span-10 px-8 lg:px-0 lg:col-start-2 lg:col-span-8"
+        >
+          <template v-for="(s, i) in content.sections">
+            <!-- Only show headers for sections after the first one -->
+            <h2
+              v-if="i > 0 && s.name.length > 0"
+              class="mt-8 mb-2"
+              :key="`header-${s.name}`"
+            >
+              {{ s.name }}
+            </h2>
+            <!-- The 'prose' class comes from the Tailwind typography plugin -->
+            <div
+              v-if="s.content.length > 0"
+              class="prose mt-4 lg:mt-8"
+              :key="`content-${s.name}`"
+              v-html="sanitize(s.content)"
+            ></div>
+          </template>
+        </div>
+
+        <!-- For debugging only: refresh content button -->
+        <div v-if="showRefreshButton" class="fixed z-50 bottom-4 right-4">
+          <MaterialButton
+            type="primary"
+            class="mt-8"
+            @click.native="refreshContent()"
+          >
+            Refresh
+          </MaterialButton>
         </div>
       </div>
-    </template>
-
-    <!-- Body -->
-    <div class="grid grid-cols-10 gap-4 mb-10 lg:mb-20">
-      <div
-        v-if="content != null"
-        class="col-span-10 px-8 lg:px-0 lg:col-start-2 lg:col-span-8"
-      >
-        <template v-for="(s, i) in content.sections">
-          <!-- Only show headers for sections after the first one -->
-          <h2
-            v-if="i > 0 && s.name.length > 0"
-            class="mt-8 mb-2"
-            :key="`header-${s.name}`"
-          >
-            {{ s.name }}
-          </h2>
-          <!-- The 'prose' class comes from the Tailwind typography plugin -->
-          <div
-            v-if="s.content.length > 0"
-            class="prose mt-4 lg:mt-8"
-            :key="`content-${s.name}`"
-            v-html="sanitize(s.content)"
-          ></div>
-        </template>
-      </div>
-
-      <!-- For debugging only: refresh content button -->
-      <div v-if="showRefreshButton" class="fixed z-50 bottom-4 right-4">
-        <MaterialButton
-          type="primary"
-          class="mt-8"
-          @click.native="refreshContent()"
-        >
-          Refresh
-        </MaterialButton>
-      </div>
-    </div>
-  </HeaderBodyLayout>
+    </HeaderBodyLayout>
+  </div>
 </template>
 
 <script lang="ts">
-import { Component, Vue } from "vue-property-decorator";
+import { Component, Prop, Vue } from "vue-property-decorator";
 import { getModule } from "vuex-module-decorators";
 import DOMPurify from "dompurify";
 
 import MaterialButton from "@/components/MaterialButton.vue";
 import AuthorLink from "@/components/AuthorLink.vue";
 import HeaderBodyLayout from "@/components/HeaderBodyLayout.vue";
+import Breadcrumbs from "@/components/Breadcrumbs.vue";
 import UIModule from "@/store/ui";
 
 import { ALL_PRODUCTS } from "../../../shared/product";
 import {
   AuthorData,
+  BreadcrumbLink,
   RepoData,
   RepoPage,
   ProductConfig,
@@ -190,6 +195,7 @@ declare const hljs: any;
     MaterialButton,
     AuthorLink,
     HeaderBodyLayout,
+    Breadcrumbs,
   },
 })
 export default class Repo extends Vue {
@@ -197,6 +203,15 @@ export default class Repo extends Vue {
   public repo: RepoData | null = null;
   public content: RepoPage | null = null;
   public authors: AuthorData[] = [];
+
+  public getBreadcrumbs(): BreadcrumbLink[] {
+    return [
+      {name: "Products", clickable: false},
+      {name: this.product?.name ?? 'Product', clickable: true},
+      {name: "Repos", clickable: false},
+      {name: this.repo?.metadata.name ?? 'Repo', clickable: true},
+    ];
+  }
 
   private productKey!: string;
   private id!: string;

--- a/app/tailwind.config.js
+++ b/app/tailwind.config.js
@@ -112,7 +112,9 @@ module.exports = {
     },
   },
   variants: {
-    extend: {},
+    extend: {
+      textColor: ['last'],
+    },
   },
   plugins: [require("@tailwindcss/typography")],
 };

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -136,3 +136,8 @@ export interface RepoDataHolder {
 }
 
 export type BlogOrRepoDataHolder = BlogDataHolder | RepoDataHolder;
+
+export interface BreadcrumbLink {
+  name: string;
+  clickable: boolean;
+}


### PR DESCRIPTION
Adds interactable breadcrumbs for navigation, eg.
<img width="691" alt="Screen Shot 2022-08-19 at 17 40 20" src="https://user-images.githubusercontent.com/9669142/185666705-d25e772e-2179-48a6-a5ae-04064cd67de7.png">

<img width="671" alt="Screen Shot 2022-08-19 at 17 39 43" src="https://user-images.githubusercontent.com/9669142/185666632-e28b259a-2808-4381-ad08-4f849982c8ea.png">

