### PR TITLE
Added functionality to redirect to authors profile on Repo Card

### DIFF
--- a/app/src/components/LargeRepoCard.vue
+++ b/app/src/components/LargeRepoCard.vue
@@ -20,15 +20,20 @@
   >
     <!-- Author photo and name -->
     <div class="frc">
-      <CircleImage
-        v-if="authorImageLoaded"
-        :lazy="true"
-        size="card-avatar"
-        class="mr-2"
-        :src="`https://avatars.githubusercontent.com/${repo.metadata.owner}`"
-      />
-      <div v-else v-html="dynamicAuthorImage"></div>
-      <span class="font-display text-lg">{{ repo.metadata.owner }}</span>
+      <!-- Link to author (if present) -->
+      <template v-if="authorId">
+        <router-link :to="`/authors/${authorId}`" class="frc">
+            <CircleImage
+              v-if="authorImageLoaded"
+              :lazy="true"
+              size="card-avatar"
+              class="mr-2"
+              :src="`https://avatars.githubusercontent.com/${repo.metadata.owner}`"
+            />
+            <div v-else v-html="dynamicAuthorImage"></div>
+            <span class="font-display text-lg">{{ repo.metadata.owner }}</span>
+        </router-link>
+      </template>
 
       <ProductLogo
         v-if="showLogo"

--- a/app/src/components/LargeRepoCard.vue
+++ b/app/src/components/LargeRepoCard.vue
@@ -183,6 +183,17 @@ export default class LargeRepoCard extends Vue {
     return Math.abs(hash);
   }
 
+  get authorId() {
+    if (
+      this.repo.metadata.authorIds &&
+      this.repo.metadata.authorIds.length > 0
+    ) {
+      return this.repo.metadata.authorIds[0];
+    }
+
+    return undefined;
+  }
+
   get link() {
     return `/products/${this.repo.product}/repos/${this.repo.id}`;
   }


### PR DESCRIPTION
https://buganizer.corp.google.com/issues/250524498

Added router-link component to the Large Repo Card in order to have similar functionality across Products (Repos and Blogs):

1) On clicking the author logo for repos it redirects to the authors profile - this was already implemented for blogs in earlier

One file changed: LargeRepoCard.vue