### PR TITLE
Sticky filters on product page

### DIFF
--- a/app/src/components/ProjectFilters.vue
+++ b/app/src/components/ProjectFilters.vue
@@ -164,6 +164,8 @@ export default class ProjectFilters extends Vue {
 <style scoped lang="postcss">
 .desktop {
   @apply border-gray-200;
+  position: sticky;
+  top: 80px;
 }
 
 .mobile .sections {

--- a/app/src/views/Product.vue
+++ b/app/src/views/Product.vue
@@ -75,7 +75,7 @@
         <div
           v-if="$mq === 'mobile'"
           v-show="showFilterOverlay"
-          class="mobile-only scrim"
+          class="mobile-only scrim z-10"
         >
           <!-- scrim -->
         </div>
@@ -83,7 +83,7 @@
           <div
             v-if="$mq === 'mobile'"
             v-show="showFilterOverlay"
-            class="mobile-only fixed right-0 top-0 pt-20 w-full h-full"
+            class="mobile-only fixed right-0 top-0 pt-20 w-full h-full z-10"
           >
             <div class="bg-white rounded-l overflow-hidden w-2/3 ml-auto">
               <ProjectFilters


### PR DESCRIPTION
Scrolling on the products page will keep the filters sticky on the left hand side