### PR TITLE
Fix link to Google Dev Library website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## Welcome to the Google Dev Library
 
-[Google Dev Library](devlibrary.withgoogle.com) is a curated platform for technical content written or built using any of the following Google technologies. Dev Library unifies all the Google technologies in one open platform giving developers around the world access to the open source projects curated by Google engineers based on check for relevancy, usefulness, freshness, and quality. 
+[Google Dev Library](https://devlibrary.withgoogle.com) is a curated platform for technical content written or built using any of the following Google technologies. Dev Library unifies all the Google technologies in one open platform giving developers around the world access to the open source projects curated by Google engineers based on check for relevancy, usefulness, freshness, and quality. 
 
 If you are a developer who has built an open-source project, or has written about a solution you have solved using the below Google technologies you can apply to have their project or content featured on the site.
 


### PR DESCRIPTION
Clicking on the link currently leads to a 404