### PR TITLE
feat(Product): Show only 3 first tags

### DIFF
--- a/app/src/components/LargeBlogCard.vue
+++ b/app/src/components/LargeBlogCard.vue
@@ -24,11 +24,11 @@
     <!-- Tags -->
     <div v-if="showTags" class="card-tags frc mt-4 flex-wrap gap-2">
       <TagChip
-        v-for="t in blog.metadata.tags"
+        v-for="(t, index) in displayedTags"
         :key="t"
-        :label="getTag(t).label"
-        :textColor="getTag(t).textColor"
-        :bgColor="getTag(t).bgColor"
+        :label="getTag(t, index).label"
+        :textColor="getTag(t, index).textColor"
+        :bgColor="getTag(t, index).bgColor"
       />
     </div>
 
@@ -144,8 +144,18 @@ export default class LargeBlogCard extends Vue {
     return dates.renderDaysAgo(lastUpdated);
   }
 
-  public getTag(value: string) {
-    return product.getTag(this.blog.product, value);
+  get displayedTags() {
+    return this.blog.metadata.tags.slice(0, 4);
+  }
+
+  public getTag(value: string, index: number) {
+    if (index <= 2) return product.getTag(this.blog.product, value);
+
+    return {
+      label: `+${this.blog.metadata.tags.length - 3}`,
+      textColor: "text-gray-500",
+      bgColor: "bg-gray-50",
+    };
   }
 
   public async getImage() {

--- a/app/src/components/LargeBlogCard.vue
+++ b/app/src/components/LargeBlogCard.vue
@@ -145,7 +145,21 @@ export default class LargeBlogCard extends Vue {
   }
 
   get displayedTags() {
-    return this.blog.metadata.tags.slice(0, 4);
+    const filters = this.$route.query.category;
+    if (!filters) return this.blog.metadata.tags.slice(0, 4);
+    return this.blog.metadata.tags
+      .sort((a, b) => {
+        if (filters.includes(a) && filters.includes(b)) {
+          return a.localeCompare(b);
+        } else if (filters.includes(a)) {
+          return -1;
+        } else if (filters.includes(b)) {
+          return 1;
+        } else {
+          return a.localeCompare(b);
+        }
+      })
+      .slice(0, 4);
   }
 
   public getTag(value: string, index: number) {

--- a/app/src/components/LargeRepoCard.vue
+++ b/app/src/components/LargeRepoCard.vue
@@ -149,7 +149,21 @@ export default class LargeRepoCard extends Vue {
   }
 
   get displayedTags() {
-    return this.repo.metadata.tags.slice(0, 4);
+    const filters = this.$route.query.category;
+    if (!filters) return this.repo.metadata.tags.slice(0, 4);
+    return this.repo.metadata.tags
+      .sort((a, b) => {
+        if (filters.includes(a) && filters.includes(b)) {
+          return a.localeCompare(b);
+        } else if (filters.includes(a)) {
+          return -1;
+        } else if (filters.includes(b)) {
+          return 1;
+        } else {
+          return a.localeCompare(b);
+        }
+      })
+      .slice(0, 4);
   }
 
   public getTag(value: string, index: number) {

--- a/app/src/components/LargeRepoCard.vue
+++ b/app/src/components/LargeRepoCard.vue
@@ -24,11 +24,11 @@
     <!-- Tags -->
     <div v-if="showTags" class="card-tags mt-4 frc flex-wrap gap-2">
       <TagChip
-        v-for="t in repo.metadata.tags"
+        v-for="(t, index) in displayedTags"
         :key="t"
-        :label="getTag(t).label"
-        :textColor="getTag(t).textColor"
-        :bgColor="getTag(t).bgColor"
+        :label="getTag(t, index).label"
+        :textColor="getTag(t, index).textColor"
+        :bgColor="getTag(t, index).bgColor"
       />
     </div>
 
@@ -148,8 +148,18 @@ export default class LargeRepoCard extends Vue {
     return dates.renderDaysAgo(lastUpdated);
   }
 
-  public getTag(value: string) {
-    return product.getTag(this.repo.product, value);
+  get displayedTags() {
+    return this.repo.metadata.tags.slice(0, 4);
+  }
+
+  public getTag(value: string, index: number) {
+    if (index <= 2) return product.getTag(this.repo.product, value);
+
+    return {
+      label: `+${this.repo.metadata.tags.length - 3}`,
+      textColor: "text-gray-500",
+      bgColor: "bg-gray-50",
+    };
   }
 
   get authorPhotoUrl(): string {
@@ -237,3 +247,4 @@ export default class LargeRepoCard extends Vue {
 </script>
 
 <style scoped lang="postcss"></style>
+i

--- a/app/src/components/RadioGroup.vue
+++ b/app/src/components/RadioGroup.vue
@@ -38,7 +38,7 @@
           <div class="mdc-radio__inner-circle"></div>
         </div>
       </div>
-      <label class="text-sm">{{ entry.key }}</label>
+      <span class="text-sm">{{ entry.key }}</span>
     </label>
   </div>
 </template>

--- a/app/src/views/Product.vue
+++ b/app/src/views/Product.vue
@@ -469,6 +469,7 @@ export default class Product extends Vue {
     }
     if (hasCategoryParams) {
       url += `&category=${categoryParams}`;
+      this.$route.query.category = categoryParams;
     }
     window.history.replaceState(null, "", url);
   }


### PR DESCRIPTION
### This PR has to goal to display only the first three tags in the cards of the product page.
[Preview link here](https://ugc-site-dev--limit-tags-number-my38gv6b.web.app/)

**Current Behaviour :** Content cards in the product page show all tags that the contributor / curator has added. However, when the content card has more than 5 tags its hard to read the rest of the card.

**Desired Behaviour :** We should only show 3 tags on the card. If the content card has more than 3 tags, the third tag should be truncated to show just the number of hidden tags. Sample UX which shows behaviour

<img width="1685" alt="7TNCtgyGdztpJgY" src="https://user-images.githubusercontent.com/70767539/222961921-448b1729-db45-4488-b0b3-d386944c2ef4.png">