### PR TITLE
Update Node version from 12 to 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
+          - 16.x
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 12.x
+          - 16.x
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-node@v1

--- a/app/app.yaml
+++ b/app/app.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-runtime: nodejs12
+runtime: nodejs16
 handlers:
 # Serve all static files with url ending with a file extension
 - url: /(.*\..+)$

--- a/cloudbuild/deploy.yaml
+++ b/cloudbuild/deploy.yaml
@@ -14,22 +14,22 @@
 
 timeout: 1800s
 steps:
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=shared', 'install']
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=app', 'install']
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=functions', 'install']
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=functions', 'run', 'build']
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=app', 'run', 'build:$PROJECT_ID']
-- name: 'node:12'
+- name: 'node:16'
   entrypoint: 'npm'
   args: ['--prefix=shared', 'run', 'deploy:firebase']
   env:

--- a/functions/package.json
+++ b/functions/package.json
@@ -8,7 +8,7 @@
     "serve": "tsc-watch --onFirstSuccess 'npm run emulate'"
   },
   "engines": {
-    "node": "12"
+    "node": "16"
   },
   "main": "lib/index.js",
   "dependencies": {


### PR DESCRIPTION
Updated Node to the most stable version for our current dependencies. Does not require updates to our other dependencies or package-lock.