### PR TITLE
Remove Vue Router OG Meta logic

### DIFF
--- a/app/public/index.html
+++ b/app/public/index.html
@@ -51,6 +51,7 @@
 
     <!-- Basic OpenGraph Tags -->
     <meta property="og:title" content="Google Dev Library | What will you build?" />
+    <meta property="og:image" content="https://devlibrary.withgoogle.com/img/dev-library.png" />
 
     <!-- HighlightJS (deferred for performance) -->
     <link href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.6.0/styles/a11y-dark.min.css" rel="preload" as="style" onload="this.onload=null;this.rel='stylesheet'">

--- a/app/src/router/index.ts
+++ b/app/src/router/index.ts
@@ -34,191 +34,51 @@ const routes: Array<RouteConfig> = [
     path: "/",
     name: "Home",
     component: Home,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-      ],
-    },
   },
   {
     path: "/products/:product",
     name: "Product",
     component: Product,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/products/:product/repos/:repo",
     name: "Repo",
     component: Repo,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/products/:product/repos/:repo/pages/:page(.*)",
     name: "RepoPage",
     component: Repo,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/product-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/featured-content",
     name: "Featured Content",
     component: FeaturedContent,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/featured-content-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/featured-content-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/authors",
     name: "Authors",
     component: Authors,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/authors-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/authors-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/authors/:author",
     name: "Author",
     component: Author,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/authors-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/authors-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/about",
     name: "About",
     component: About,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/about-clipart.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/banners/desktop/about-clipart.png",
-        },
-      ],
-    },
   },
   {
     path: "/contentpolicy",
     name: "ContentPolicy",
     component: ContentPolicy,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-      ],
-    },
   },
   {
     path: "*",
     name: "404",
     component: FourOhFour,
-    meta: {
-      metaTags: [
-        {
-          name: "image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-        {
-          property: "og:image",
-          content:
-            "https://devlibrary.withgoogle.com/img/dev-library-preview.png",
-        },
-      ],
-    },
   },
 ];
 
@@ -228,67 +88,6 @@ const router = new VueRouter({
   scrollBehavior() {
     return { x: 0, y: 0 };
   },
-});
-
-/**
- * This callback runs before every route change, including on page load.
- * Reference: https://www.digitalocean.com/community/tutorials/vuejs-vue-router-modify-head
- */
-router.beforeEach((to, from, next) => {
-  /**
-   * This goes through the matched routes from last to first, finding the closest route with a title.
-   * e.g., if we have `/some/deep/nested/route` and `/some`, `/deep`, and `/nested` have titles,
-   * `/nested`'s will be chosen.
-   */
-  const nearestWithTitle = to.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.title);
-
-  // Find the nearest route element with meta tags.
-  const nearestWithMeta = to.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.metaTags);
-
-  const previousNearestWithMeta = from.matched
-    .slice()
-    .reverse()
-    .find((r) => r.meta && r.meta.metaTags);
-
-  // If a route with a title was found, set the document (page) title to that value.
-  if (nearestWithTitle) {
-    document.title = nearestWithTitle.meta.title;
-  } else if (previousNearestWithMeta) {
-    document.title = previousNearestWithMeta.meta.title;
-  }
-
-  // Remove any stale meta tags from the document using the key attribute we set below.
-  Array.from(document.querySelectorAll("[data-vue-router-controlled]")).map(
-    (el) => el.parentNode!.removeChild(el)
-  );
-
-  // Skip rendering meta tags if there are none.
-  if (!nearestWithMeta) return next();
-
-  // Turn the meta tag definitions into actual elements in the head.
-  nearestWithMeta.meta.metaTags
-    .map((tagDef: { [x: string]: string }) => {
-      const tag = document.createElement("meta");
-
-      Object.keys(tagDef).forEach((key) => {
-        tag.setAttribute(key, tagDef[key]);
-      });
-
-      // We use this to track which meta tags we create so we don't interfere with other ones.
-      tag.setAttribute("data-vue-router-controlled", "");
-
-      return tag;
-    })
-    // Add the meta tags to the document head.
-    .forEach((tag: Node) => document.head.appendChild(tag));
-
-  next();
 });
 
 router.afterEach((to, from) => {


### PR DESCRIPTION
The previous Vue Router OG Meta logic I had does not work for our use case since crawlers from previews act before the meta data gets added.

I removed it and have placed the default preview image statically within index.html instead.

If we want the preview image to be different dynamically we would need a server side rendering solution - and currently we don't have this - which would be a larger task... 

Merging this PR would make the title and preview image the same across all pages for dev library.
If we wanted different titles and images, we would need to do my suggestion (or find another alternative)

Thoughts?